### PR TITLE
Add devcontainer configuration for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# Use mcr.microsoft.com/devcontainers/python:3.12 as the base image
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+# Install any additional dependencies if needed
+# Example: RUN apt-get update && apt-get install -y <package-name>
+RUN apt-get update && apt-get install -y uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "enkia.tokyo-night",
+        "GitHub.copilot",
+        "GitHub.copilot-chat"
+      ],
+      "settings": {
+        "workbench.colorTheme": "Tokyo Night",
+        "github.copilot.enable": {
+          "markdown": true
+        }
+      }
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/uv:1": {}
+  }
+}


### PR DESCRIPTION
Add devcontainer configuration for GitHub Codespaces.

* **.devcontainer/devcontainer.json**
  - Set the image to `mcr.microsoft.com/devcontainers/python:3.12`
  - Add extensions `enkia.tokyo-night`, `GitHub.copilot`, and `GitHub.copilot-chat` under `customizations.vscode.extensions`
  - Add settings for `workbench.colorTheme` and `github.copilot.enable` under `customizations.vscode.settings`
  - Add `uv` as a dependency in the `features` section

* **.devcontainer/Dockerfile**
  - Use `mcr.microsoft.com/devcontainers/python:3.12` as the base image
  - Install `uv` as an additional dependency

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yumechi/python_practice/pull/54?shareId=286eece0-e30b-45e8-aadb-5f6109c5ae2f).