### PR TITLE
chore: GitHub Actions のバージョン更新と SHA 固定

### DIFF
--- a/.github/workflows/manual-merge-dependabot.yml
+++ b/.github/workflows/manual-merge-dependabot.yml
@@ -10,7 +10,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: List Dependabot PRs
         run: |
           gh pr list --author dependabot[bot] --json number,title,url
@@ -22,7 +22,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Merge Dependabot PRs
         run: |
           prs=$(gh pr list --author dependabot[bot] --json number --jq '.[].number')


### PR DESCRIPTION
## Summary
- サプライチェーン攻撃対策として GitHub Actions の参照を SHA に固定
- 同時に最新バージョン (リリースから 7 日以上経過したもの) に更新
- `pinact run --update --min-age 7` で実施

## メジャー version 跨ぎ
- `actions/checkout` v4 → v6

## Test plan
- [ ] workflow が文法的に valid であること
- [ ] 手動実行で dependabot PR の操作が機能することを確認